### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.3
+Django==1.11.17
 psycopg2==2.6.2
 dj_database_url==0.4.2
 whitenoise==3.3.0


### PR DESCRIPTION
With Python 3.7 , manage.py file shows error message which reads "SyntaxError: Generator expression must be parenthesized". We can fix it by upgrading Django to 1.11.17 . This problem can also be seen in this forum post: https://stackoverflow.com/questions/51265858/syntaxerror-generator-expression-must-be-parenthesized